### PR TITLE
Edited MLH_intro_landing and verified MLH_download

### DIFF
--- a/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
+++ b/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
@@ -72,7 +72,7 @@ code: |
   snapshot_start
   nav.set_section("review_full")
   nav.set_section("signpost_intro")
-  MLH_intro_landing
+  DPA_intro_landing
   do_not_use_for
 
   nav.set_section("review_parent_info")
@@ -220,7 +220,7 @@ code: |
 ---
 ###################### Questions Start ######################
 ---
-id: MLH intro landing FirstScreen
+id: DPA intro landing FirstScreen
 question: |
   Delegation of Parental Authority
 subquestion: |
@@ -234,7 +234,7 @@ subquestion: |
   
   When you are finished, you will need need to **print and sign** this form to make it effective.
 
-continue button field: MLH_intro_landing
+continue button field: DPA_intro_landing
 ---
 template: process_info
 subject: |

--- a/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
+++ b/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
@@ -8,7 +8,7 @@ metadata:
   title: >-
     Delegation of Parental Authority
   short title: >-
-    Temporary parental powers
+    Delegation of Parental Authority
   description: |-
     This interview helps someone in Michigan make a Delegation of Parental Authority.
   tags: []
@@ -72,8 +72,7 @@ code: |
   snapshot_start
   nav.set_section("review_full")
   nav.set_section("signpost_intro")
-  al_intro_screen
-  delegation_of_parental_authority_intro
+  MLH_intro_landing
   do_not_use_for
 
   nav.set_section("review_parent_info")
@@ -221,27 +220,37 @@ code: |
 ---
 ###################### Questions Start ######################
 ---
-comment: |
-  This question is used to introduce your interview. Please customize
-id: Delegation_of_parental_authority
-continue button field: delegation_of_parental_authority_intro
+id: MLH intro landing FirstScreen
 question: |
   Delegation of Parental Authority
 subquestion: |
-  This interview will help you make a Delegation of Parental Authority and a set of step-by-step instructions.
+  Welcome to the ${ MLH_interview_short_title } tool. 
   
+  This tool will help you prepare the forms you will need to give someone besides you (or your children's other parent) temporary legal power to make decisions for your children. 
+  
+  ${ collapse_template(process_info) }
+  
+  Most people take about **15-30 minutes** to finish this interview. 
+  
+  When you are finished, you will need need to **print and sign** this form to make it effective.
+
+continue button field: MLH_intro_landing
+---
+template: process_info
+subject: |
+  What information will I need to use this tool?
+content: |
   Before you get started, please gather:
   
   1. Contact information for the person you want to give parental authority to.
-  2. **Optional**: Your children's health care information, including:
-    
-  * allergies
-  * medications
-  * insurance
-  * providers
-  * preferred hospital
-  
-  Most people take about 15-30 minutes to finish this interview. When you are finished, you need to print and sign this form to make it effective.
+  2. (Optional) Your children's health care information, including:
+      * allergies
+      * medications
+      * insurance
+      * providers
+      * preferred hospital
+
+  To learn more about getting a Delegation of Parental Authority, read [Giving Someone Temporary Legal Power to Make Decisions for Your Child](https://michiganlegalhelp.org/resources/family/giving-someone-temporary-legal-power-make-decisions-your-child).
 ---
 id: Do Not Use Warnings
 continue button field: do_not_use_for


### PR DESCRIPTION
Fixed #1 

- Replaced intro landing screen with MLH_intro_landing. Also edited contents of landing page, including collapsible help section.
- Verified that MLH_download was being used for download screen. 

Per the documentation, since MLH_intro_landing and MLH_download are being used , nothing needed to be added to the question id's. However, I did notice that the in the PPO we still added "FirstScreen" to the question id for MLH_intro_landing, so I did the same here—just in case there might've been a special reason for the redundancy.