### PR TITLE
Added max to children.target_number

### DIFF
--- a/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
+++ b/docassemble/DelegationParentalAuthority/data/questions/delegation_of_parental_authority.yml
@@ -389,6 +389,7 @@ fields:
   - How many children will be included in your form?: children.target_number
     datatype: integer 
     min: 1
+    max: 20
 ---
 template: adding_children
 subject: |


### PR DESCRIPTION
Fixed #9 
- Added max limit of 20 to `children.target_number` field.